### PR TITLE
adapt ext_tables.sql ... placeholder text

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -12,7 +12,7 @@ CREATE TABLE tx_media2click_domain_model_host
     title VARCHAR(128) DEFAULT '' NOT NULL,
     host VARCHAR(128) DEFAULT '' NOT NULL,
     privacy_statement_link VARCHAR(1024) DEFAULT '' NOT NULL,
-    placeholder text DEFAULT '' NOT NULL,
+    placeholder text,
     allow_permanent int(3) DEFAULT '0' NOT NULL,
     logo int(3) DEFAULT '0' NOT NULL
 );


### PR DESCRIPTION
in v12 DB compare suggests to change fields ... and repeats this on next compare

ALTER TABLE `tx_media2click_domain_model_host` CHANGE `placeholder` `placeholder` TEXT NOT NULL
Current value: placeholder TEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_general_ci` 

as far as i know, text should not have any default
(https://blog.sbtheke.de/web-development/typo3/typo3-programmierung/typo3-konforme-sql-anweisungen-in-ext_tables-sql)

with this change DB compare is satisfied