### PR TITLE
fix typoscript loading order

### DIFF
--- a/Configuration/Sets/Media2click/config.yaml
+++ b/Configuration/Sets/Media2click/config.yaml
@@ -1,2 +1,4 @@
 name: amazing/media2click
 label: 2 Clicks for External Media
+dependencies:
+  - typo3/fluid-styled-content


### PR DESCRIPTION
Hi there,

I noticed an issue with the order typoscript is loaded. especially lib.contentElement from fluid_styled_content.

this happend when deploying the instance (e.g. a fresh install).

TYPO3 13.4.17
media2click 3.5.3

my local instance does not have this issue. even when doing a fresh install (remove vendor). 

adding `typo3/fluid-styled-content` as dependency of the media2click set fixes the issue.